### PR TITLE
Use HTTPS in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ store = MemoryTokenStore()
 client = L402Client(wallet=wallet, store=store)
 
 # Use the client to send HTTP requests
-response = client.get('http://rnd.ln.sulu.sh/randomnumber')
+response = client.get('https://rnd.ln.sulu.sh/randomnumber')
 print(response.text)
 ```
 


### PR DESCRIPTION
The sample L402 call to the random number endpoint using HTTP responded with a redirect and the current sample code does not follow the redirect. Using HTTPS solves this.